### PR TITLE
Fixed format strings to use zx instead of x for size_t's

### DIFF
--- a/src/Source.cpp
+++ b/src/Source.cpp
@@ -80,7 +80,7 @@ STATUS getFreedChunk(HANDLE hHeap, size_t size) {
 	
 	chunk = HeapAlloc(hHeap, 0x0, size);
 	HeapFree(hHeap, 0x0, chunk);
-	printf("[*] Chunk 0x%p is freed in the userblocks for bucket size 0x%x\n", chunk, size);
+	printf("[*] Chunk 0x%p is freed in the userblocks for bucket size 0x%zx\n", chunk, size);
 
 	for (size_t i = 0; i < RandomDataArrayLength - 1; ++i) {
 		tmp_chunk = HeapAlloc(hHeap, 0x0, size);
@@ -115,7 +115,7 @@ STATUS getContiguousAllocations(HANDLE hHeap, size_t size) {
 	LPVOID chunk, tmp_chunk;
 
 	chunk = HeapAlloc(hHeap, 0x0, size);
-	printf("[*] Chunk 0x%p is freed in the userblocks for bucket size 0x%x\n", chunk, size);
+	printf("[*] Chunk 0x%p is freed in the userblocks for bucket size 0x%zx\n", chunk, size);
 
 	for (size_t i = 0; i < RandomDataArrayLength - 1; ++i) {
 		tmp_chunk = HeapAlloc(hHeap, 0x0, size);


### PR DESCRIPTION
Fixes

```
Source.cpp(83): warning C4477: 'printf' : format string '%x' requires an argument of type 'unsigned int', but variadic argument 2 has type 'size_t'
Source.cpp(83): note: consider using '%zx' in the format string
Source.cpp(118): warning C4477: 'printf' : format string '%x' requires an argument of type 'unsigned int', but variadic argument 2 has type 'size_t'
Source.cpp(118): note: consider using '%zx' in the format string
```

Just a pet peeve of mine ;)

❤️ 